### PR TITLE
fix: already processed status in snackbar

### DIFF
--- a/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/configure_fingerprint.bin
+++ b/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Logw
 u
 s/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	¦ÜË¶í2 Õ¶íê2t
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	æ÷…Ôí2 Õ¶íê2t
 r
-p/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/android_gradle_build.json	¦ÜË¶í2Ñ  Õ¶íê2y
+p/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/android_gradle_build.json	æ÷…Ôí2Ñ  Õ¶íê2y
 w
-u/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/android_gradle_build_mini.json	¦ÜË¶í2æ ¤Õ¶íê2f
+u/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/android_gradle_build_mini.json	æ÷…Ôí2æ ¤Õ¶íê2f
 d
-b/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/build.ninja	¦ÜË¶í2¯½ Õ¶íê2j
+b/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/build.ninja	æ÷…Ôí2¯½ Õ¶íê2j
 h
-f/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/build.ninja.txt	¦ÜË¶í2o
+f/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/build.ninja.txt	æ÷…Ôí2o
 m
-k/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/build_file_index.txt	¦ÜË¶í2` ¤Õ¶íê2p
+k/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/build_file_index.txt	æ÷…Ôí2` ¤Õ¶íê2p
 n
-l/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/compile_commands.json	¦ÜË¶í2t
+l/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/compile_commands.json	æ÷…Ôí2t
 r
-p/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/compile_commands.json.bin	¦ÜË¶í2	z
+p/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/compile_commands.json.bin	æ÷…Ôí2	z
 x
-v/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/metadata_generation_command.txt	¦ÜË¶í2
+v/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/metadata_generation_command.txt	æ÷…Ôí2
 Ä ¤Õ¶íê2m
 k
-i/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/prefab_config.json	¦ÜË¶í2( ¤Õ¶íê2r
+i/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/prefab_config.json	æ÷…Ôí2( ¤Õ¶íê2r
 p
-n/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/symbol_folder_index.txt	¦ÜË¶í2e ¤Õ¶íê2d
+n/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/arm64-v8a/symbol_folder_index.txt	æ÷…Ôí2e ¤Õ¶íê2d
 b
-`/home/joaoavila/development/flutter/packages/flutter_tools/gradle/src/main/groovy/CMakeLists.txt	¦ÜË¶í2¤ œé˜ëê2
+`/home/joaoavila/development/flutter/packages/flutter_tools/gradle/src/main/groovy/CMakeLists.txt	æ÷…Ôí2¤ œé˜ëê2

--- a/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/configure_fingerprint.bin
+++ b/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Logy
 w
 u/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	·ÜË¶í2 ˆ—·íê2v
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	ø÷…Ôí2 ˆ—·íê2v
 t
-r/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/android_gradle_build.json	·ÜË¶í2Õ ‹—·íê2{
+r/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/android_gradle_build.json	ø÷…Ôí2Õ ‹—·íê2{
 y
-w/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/android_gradle_build_mini.json	·ÜË¶í2ê ‹—·íê2h
+w/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/android_gradle_build_mini.json	ø÷…Ôí2ê ‹—·íê2h
 f
-d/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/build.ninja	·ÜË¶í2¹½ û–·íê2l
+d/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/build.ninja	ù÷…Ôí2¹½ û–·íê2l
 j
-h/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/build.ninja.txt	·ÜË¶í2q
+h/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/build.ninja.txt	ù÷…Ôí2q
 o
-m/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/build_file_index.txt	·ÜË¶í2` ‹—·íê2r
+m/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/build_file_index.txt	ù÷…Ôí2` ‹—·íê2r
 p
-n/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/compile_commands.json	·ÜË¶í2v
+n/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/compile_commands.json	ù÷…Ôí2v
 t
-r/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/compile_commands.json.bin	·ÜË¶í2	|
+r/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/compile_commands.json.bin	ù÷…Ôí2	|
 z
-x/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/metadata_generation_command.txt	·ÜË¶í2
+x/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/metadata_generation_command.txt	ù÷…Ôí2
 Î ‹—·íê2o
 m
-k/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/prefab_config.json	·ÜË¶í2( ‹—·íê2t
+k/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/prefab_config.json	ù÷…Ôí2( ‹—·íê2t
 r
-p/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/symbol_folder_index.txt	¸ÜË¶í2g ‹—·íê2d
+p/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/armeabi-v7a/symbol_folder_index.txt	ù÷…Ôí2g ‹—·íê2d
 b
-`/home/joaoavila/development/flutter/packages/flutter_tools/gradle/src/main/groovy/CMakeLists.txt	¸ÜË¶í2¤ œé˜ëê2
+`/home/joaoavila/development/flutter/packages/flutter_tools/gradle/src/main/groovy/CMakeLists.txt	ù÷…Ôí2¤ œé˜ëê2

--- a/android/app/.cxx/Debug/34n4p2s5/x86/configure_fingerprint.bin
+++ b/android/app/.cxx/Debug/34n4p2s5/x86/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Logq
 o
 m/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	ÄÜË¶í2 İ˜·íê2n
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	Šø…Ôí2 İ˜·íê2n
 l
-j/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/android_gradle_build.json	ÄÜË¶í2Å İ˜·íê2s
+j/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/android_gradle_build.json	Šø…Ôí2Å İ˜·íê2s
 q
-o/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/android_gradle_build_mini.json	ÄÜË¶í2Ú á˜·íê2`
+o/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/android_gradle_build_mini.json	Šø…Ôí2Ú á˜·íê2`
 ^
-\/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/build.ninja	ÄÜË¶í2‘½ Ó˜·íê2d
+\/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/build.ninja	Šø…Ôí2‘½ Ó˜·íê2d
 b
-`/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/build.ninja.txt	ÄÜË¶í2i
+`/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/build.ninja.txt	Šø…Ôí2i
 g
-e/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/build_file_index.txt	ÄÜË¶í2` á˜·íê2j
+e/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/build_file_index.txt	Šø…Ôí2` á˜·íê2j
 h
-f/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/compile_commands.json	ÄÜË¶í2n
+f/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/compile_commands.json	Šø…Ôí2n
 l
-j/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/compile_commands.json.bin	ÄÜË¶í2	t
+j/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/compile_commands.json.bin	Šø…Ôí2	t
 r
-p/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/metadata_generation_command.txt	ÄÜË¶í2
+p/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/metadata_generation_command.txt	Šø…Ôí2
 ¦ á˜·íê2g
 e
-c/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/prefab_config.json	ÄÜË¶í2( á˜·íê2l
+c/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/prefab_config.json	Šø…Ôí2( á˜·íê2l
 j
-h/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/symbol_folder_index.txt	ÄÜË¶í2_ á˜·íê2d
+h/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86/symbol_folder_index.txt	‹ø…Ôí2_ á˜·íê2d
 b
-`/home/joaoavila/development/flutter/packages/flutter_tools/gradle/src/main/groovy/CMakeLists.txt	ÄÜË¶í2¤ œé˜ëê2
+`/home/joaoavila/development/flutter/packages/flutter_tools/gradle/src/main/groovy/CMakeLists.txt	‹ø…Ôí2¤ œé˜ëê2

--- a/android/app/.cxx/Debug/34n4p2s5/x86_64/configure_fingerprint.bin
+++ b/android/app/.cxx/Debug/34n4p2s5/x86_64/configure_fingerprint.bin
@@ -2,27 +2,27 @@ C/C++ Structured Logt
 r
 p/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/additional_project_files.txtC
 A
-?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	ÏÜË¶í2 ›š·íê2q
+?com.android.build.gradle.internal.cxx.io.EncodedFileFingerPrint	”ø…Ôí2 ›š·íê2q
 o
-m/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/android_gradle_build.json	ÏÜË¶í2Ë ›š·íê2v
+m/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/android_gradle_build.json	”ø…Ôí2Ë ›š·íê2v
 t
-r/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/android_gradle_build_mini.json	ÏÜË¶í2à Ÿš·íê2c
+r/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/android_gradle_build_mini.json	”ø…Ôí2à Ÿš·íê2c
 a
-_/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/build.ninja	ÏÜË¶í2 ½ ‘š·íê2g
+_/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/build.ninja	”ø…Ôí2 ½ ‘š·íê2g
 e
-c/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/build.ninja.txt	ÏÜË¶í2l
+c/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/build.ninja.txt	”ø…Ôí2l
 j
-h/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/build_file_index.txt	ÏÜË¶í2` Ÿš·íê2m
+h/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/build_file_index.txt	”ø…Ôí2` Ÿš·íê2m
 k
-i/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/compile_commands.json	ÏÜË¶í2q
+i/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/compile_commands.json	”ø…Ôí2q
 o
-m/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/compile_commands.json.bin	ÏÜË¶í2	w
+m/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/compile_commands.json.bin	”ø…Ôí2	w
 u
-s/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/metadata_generation_command.txt	ÏÜË¶í2
+s/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/metadata_generation_command.txt	”ø…Ôí2
 µ Ÿš·íê2j
 h
-f/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/prefab_config.json	ÏÜË¶í2( Ÿš·íê2o
+f/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/prefab_config.json	”ø…Ôí2( Ÿš·íê2o
 m
-k/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/symbol_folder_index.txt	ÏÜË¶í2b Ÿš·íê2d
+k/home/joaoavila/Desktop/Projects/Flutter/tlc/android/app/.cxx/Debug/34n4p2s5/x86_64/symbol_folder_index.txt	”ø…Ôí2b Ÿš·íê2d
 b
-`/home/joaoavila/development/flutter/packages/flutter_tools/gradle/src/main/groovy/CMakeLists.txt	ÏÜË¶í2¤ œé˜ëê2
+`/home/joaoavila/development/flutter/packages/flutter_tools/gradle/src/main/groovy/CMakeLists.txt	”ø…Ôí2¤ œé˜ëê2

--- a/lib/app/global/custom_appbar.dart
+++ b/lib/app/global/custom_appbar.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_advanced_drawer/flutter_advanced_drawer.dart';
 import 'package:go_router/go_router.dart';
 import 'package:tlc/app/global/colors.dart';
 
@@ -6,11 +7,13 @@ class CustomAppbar extends StatelessWidget implements PreferredSizeWidget{
   
   final String title;
   final String? page;
+  final AdvancedDrawerController? controller;
   
   const CustomAppbar({
     super.key,
     required this.title,
-    this.page
+    this.page,
+    this.controller
   });
 
   @override
@@ -33,9 +36,7 @@ class CustomAppbar extends StatelessWidget implements PreferredSizeWidget{
       ) 
       : Builder(
         builder: (context) => IconButton(
-          onPressed: () {
-            Scaffold.of(context).openDrawer();
-          },
+          onPressed: () => controller?.showDrawer(),
           icon: Icon(Icons.menu_rounded, color: Colors.white),
         ),
       ),

--- a/lib/app/global/custom_scaffold.dart
+++ b/lib/app/global/custom_scaffold.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_advanced_drawer/flutter_advanced_drawer.dart';
+import 'package:tlc/app/global/custom_appbar.dart';
+
+class CustomScaffold extends StatelessWidget {
+
+  final String title;
+  final Widget body;
+  final String? page;
+
+  CustomScaffold({
+    super.key,
+    required this.title,
+    required this.body,
+    this.page
+  });
+
+
+  @override
+  Widget build(BuildContext context) {
+
+    final isPreview = page == 'preview';
+    final AdvancedDrawerController? _drawerController = isPreview ? null : AdvancedDrawerController();
+
+    final appBar = CustomAppbar(
+      title: title,
+      page: page,
+      controller: _drawerController,
+    );
+
+    final scaffold = Scaffold(
+      backgroundColor: const Color(0xffF9FAFB),
+      appBar: appBar,
+      body: body,
+    );
+
+    if(isPreview){
+      return scaffold;
+    }
+
+    return AdvancedDrawer(
+       controller: _drawerController,
+      animationCurve: Curves.linear,
+      animationDuration: const Duration(milliseconds: 300),
+      animateChildDecoration: true,
+      rtlOpening: false,
+      openRatio: 0.65,
+      openScale: 1,
+      drawer: Drawer(),
+      child: scaffold
+    );
+  }
+}

--- a/lib/app/global/routes.dart
+++ b/lib/app/global/routes.dart
@@ -1,7 +1,7 @@
 
 import 'package:go_router/go_router.dart';
 import 'package:tlc/app/models/cursista_model.dart';
-import 'package:tlc/app/views/import/widgets/preview_data_view.dart';
+import 'package:tlc/app/views/import/preview_data_view.dart';
 
 import '../views/auth/auth_view.dart';
 import '../views/home/home_view.dart';

--- a/lib/app/views/auth/auth_view.dart
+++ b/lib/app/views/auth/auth_view.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:go_router/go_router.dart';
@@ -35,7 +34,7 @@ class AuthView extends StatelessWidget {
               welcomeWidget(),
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 40),
-                width: MediaQuery.of(context).size.width,
+                width: double.infinity,
                 child: Form(
                   key: _formKey,
                   child: Column(
@@ -129,7 +128,7 @@ class AuthView extends StatelessWidget {
               ),
               Container(
                 margin: EdgeInsets.symmetric(horizontal: 20,),
-                width: MediaQuery.of(context).size.width,
+                width: double.infinity,
                 height: 50,
                 child: ElevatedButton(
                   style: ElevatedButton.styleFrom(

--- a/lib/app/views/import/import_view.dart
+++ b/lib/app/views/import/import_view.dart
@@ -1,146 +1,149 @@
-import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
-import 'package:google_fonts/google_fonts.dart';
-import 'package:provider/provider.dart';
-import 'package:tlc/app/views/auth/widgets/snackbar_widget.dart';
-import 'package:tlc/app/views/import/widgets/csv_file_selector_widget.dart';
+  import 'package:flutter/material.dart';
+  import 'package:flutter_advanced_drawer/flutter_advanced_drawer.dart';
+  import 'package:go_router/go_router.dart';
+  import 'package:google_fonts/google_fonts.dart';
+  import 'package:provider/provider.dart';
+  import 'package:tlc/app/views/auth/widgets/snackbar_widget.dart';
+  import 'package:tlc/app/views/import/widgets/csv_file_selector_widget.dart';
 
-import '../../global/custom_appbar.dart';
-import '../../models/cursista_model.dart';
-import '../../viewmodels/import_view_model.dart';
+  import '../../global/custom_appbar.dart';
+  import '../../global/custom_scaffold.dart';
+  import '../../models/cursista_model.dart';
+  import '../../viewmodels/import_view_model.dart';
 
-class ImportView extends StatelessWidget {
-  const ImportView({super.key});
+  class ImportView extends StatelessWidget {
 
-  @override
-  Widget build(BuildContext context) {
+    const ImportView({super.key});
 
-    return Scaffold(
-      backgroundColor: Color(0xffF9FAFB),
-      appBar: CustomAppbar(title: "Importar Dados"),
-      drawer: Drawer(),
-      body: SingleChildScrollView(
-        child: Container(
-          margin: EdgeInsets.symmetric(horizontal: 10, vertical: 20),
-          padding: EdgeInsets.symmetric(horizontal: 20, vertical: 20),
-          decoration: BoxDecoration(
-            color: Colors.white,
-            border: Border.all(
-              color: Colors.grey.shade300,
-              width: 1
+    @override
+    Widget build(BuildContext context) {
+
+      return CustomScaffold(
+        title: "Importar dados",
+        body: SingleChildScrollView(
+          child: Container(
+            margin: EdgeInsets.symmetric(horizontal: 10, vertical: 20),
+            padding: EdgeInsets.symmetric(horizontal: 20, vertical: 20),
+            decoration: BoxDecoration(
+              color: Colors.white,
+              border: Border.all(
+                color: Colors.grey.shade300,
+                width: 1
+              ),
+              borderRadius: BorderRadius.circular(10)
             ),
-            borderRadius: BorderRadius.circular(10)
-          ),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                "Importar Arquivo CSV",
-                style: GoogleFonts.raleway(
-                  fontSize: 24,
-                  fontWeight: FontWeight.w700
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  "Importar Arquivo CSV",
+                  style: GoogleFonts.raleway(
+                    fontSize: 24,
+                    fontWeight: FontWeight.w700
+                  ),
                 ),
-              ),
-              Text(
-                "Selecione o arquivo CSV exportado do Google Forms para importar os dados dos cursistas.",
-                softWrap: true,
-                style: TextStyle(
-                  fontSize: 13,
-                  fontWeight: FontWeight.w900,
-                  color: Colors.grey.shade600
+                Text(
+                  "Selecione o arquivo CSV exportado do Google Forms para importar os dados dos cursistas.",
+                  softWrap: true,
+                  style: TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w900,
+                    color: Colors.grey.shade600
+                  ),
                 ),
-              ),
-              SizedBox(height: 20,),
-              Selector<ImportViewModel, String?>(
-                selector: (_, vm) => vm.fileName,
-                builder: (context, fileName, _) {
-                  return CsvFileSelectorWidget(
-                    fileName: fileName, 
-                    onSelectFile: () async {
-                      final vm = context.read<ImportViewModel>();
-                      final status = await vm.uploadCsvFile();
-                      if (!context.mounted) return;
-
-                      if (status == CsvImportStatus.success){
-                        snackbarWidget("Dados carregados com sucesso", context);
-                      } else if (status == CsvImportStatus.cancelled){
-                        snackbarWidget("Seleção de arquivo cancelada", context);
-                      } else {
-                        snackbarWidget("Erro ao importar o arquivo CSV: ${vm.errorMessage}", context);
-                        vm.clearError();
+                SizedBox(height: 20,),
+                Selector<ImportViewModel, String?>(
+                  selector: (_, vm) => vm.fileName,
+                  builder: (context, fileName, _) {
+                    return CsvFileSelectorWidget(
+                      fileName: fileName, 
+                      onSelectFile: () async {
+                        final vm = context.read<ImportViewModel>();
+                        final status = await vm.uploadCsvFile();
+                        if (!context.mounted) return;
+      
+                        if (status == CsvImportStatus.success){
+                          snackbarWidget("Dados carregados com sucesso", context);
+                        } else if (status == CsvImportStatus.cancelled){
+                          snackbarWidget("Seleção de arquivo cancelada", context);
+                        }else if (status == CsvImportStatus.alreadyProcessed){
+                          snackbarWidget("Arquivo já importado", context);
+                        } else {
+                          snackbarWidget("Erro ao importar o arquivo CSV: ${vm.errorMessage}", context);
+                          vm.clearError();
+                        }
                       }
-                    }
-                  );
-                }
-              ),
-              SizedBox(height: 20,),
-              SizedBox(
-                width: double.infinity,
-                child: Selector<ImportViewModel, List<CursistaModel>>(
-                  selector: (_, vm) => vm.cursistas,
-                  builder: (context, cursistas, _){
-                    if(cursistas.isEmpty){
-                      return SizedBox.shrink();
-                    }
-                    return OutlinedButton.icon(
-                      icon: Icon(Icons.remove_red_eye_outlined, color: Colors.black),
-                      onPressed: context.read<ImportViewModel>().isLoading
-                          ? null
-                          : () async {
-                              final vm = context.read<ImportViewModel>();
-                              if (vm.selectedFile != null) {
-                                if (vm.errorMessage == null && vm.cursistas.isNotEmpty) {
-                                  context.push('/preview', extra: vm.cursistas);
-                                }
-                              }
-                            },
-                      style: OutlinedButton.styleFrom(
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(5),
-                        ),
-                      ),
-                      label: Text(
-                        "Visualizar dados dos cursistas",
-                        style: TextStyle(color: Colors.black),
-                      ),
-                    );
-                  },
-                ),
-              ),
-
-              SizedBox(height: 20,),
-              Selector<ImportViewModel, bool>(
-                  selector: (_, vm) => vm.isFilePicked,
-                  builder: (context, isFilePicked, _) {
-                    return SizedBox(
-                      width: double.infinity,
-                      child: ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Colors.black,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(5),
-                          ),
-                          disabledBackgroundColor: Colors.grey
-                        ),
-                        onPressed: isFilePicked ? () async {
-                          
-                        } : null, 
-                        child: Text(
-                          "Importar Dados",
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontWeight: FontWeight.w600
-                          ),
-                        )
-                      ),
                     );
                   }
                 ),
-
-            ],
+                SizedBox(height: 20,),
+                SizedBox(
+                  width: double.infinity,
+                  child: Selector<ImportViewModel, List<CursistaModel>>(
+                    selector: (_, vm) => vm.cursistas,
+                    builder: (context, cursistas, _){
+                      if(cursistas.isEmpty){
+                        return SizedBox.shrink();
+                      }
+                      return OutlinedButton.icon(
+                        icon: Icon(Icons.remove_red_eye_outlined, color: Colors.black),
+                        onPressed: context.read<ImportViewModel>().isLoading
+                            ? null
+                            : () async {
+                                final vm = context.read<ImportViewModel>();
+                                if (vm.selectedFile != null) {
+                                  if (vm.errorMessage == null && vm.cursistas.isNotEmpty) {
+                                    context.push('/preview', extra: vm.cursistas);
+                                  }
+                                }
+                              },
+                        style: OutlinedButton.styleFrom(
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(5),
+                          ),
+                        ),
+                        label: Text(
+                          "Visualizar dados dos cursistas",
+                          style: TextStyle(color: Colors.black),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+      
+                SizedBox(height: 20,),
+                Selector<ImportViewModel, bool>(
+                    selector: (_, vm) => vm.isFilePicked,
+                    builder: (context, isFilePicked, _) {
+                      return SizedBox(
+                        width: double.infinity,
+                        child: ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.black,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(5),
+                            ),
+                            disabledBackgroundColor: Colors.grey
+                          ),
+                          onPressed: isFilePicked ? () async {
+                            
+                          } : null, 
+                          child: Text(
+                            "Importar Dados",
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontWeight: FontWeight.w600
+                            ),
+                          )
+                        ),
+                      );
+                    }
+                  ),
+      
+              ],
+            ),
           ),
         ),
-      ),
-    );
+      );
+    }
   }
-}

--- a/lib/app/views/import/preview_data_view.dart
+++ b/lib/app/views/import/preview_data_view.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:tlc/app/global/custom_scaffold.dart';
+import 'package:tlc/app/views/import/widgets/custom_data_cell_widget.dart';
+
+import '../../global/colors.dart';
+import '../../global/custom_appbar.dart';
+import '../../models/cursista_model.dart';
+import '../../viewmodels/preview_data_view_model.dart';
+import 'widgets/custom_data_column.dart';
+
+class PreviewDataView extends StatelessWidget {
+  final List<CursistaModel> cursistas;
+
+  const PreviewDataView({super.key, required this.cursistas});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<PreviewDataViewModel>(
+      builder: (context, vm, _) {
+        return CustomScaffold(
+          title: "Visualizar Dados",
+          page: "preview",
+          body: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: Row(
+                  children: [
+                    const Text("Zoom"),
+                    Expanded(
+                      child: Slider(
+                        activeColor: AppColors.DARK_BROWN,
+                        value: vm.zoom, 
+                        min: 0.6,
+                        max: 1.0,
+                        divisions: 5,
+                        label: "${(vm.zoom * 100).toInt()}",
+                        onChanged: (value) => vm.setZoom(value)
+                      )
+                    )
+                  ],
+                ),
+              ),
+              Expanded(
+                child: SingleChildScrollView(
+                  scrollDirection: Axis.vertical,
+                  child: SingleChildScrollView(
+                    scrollDirection: Axis.horizontal,
+                    child: DataTable(
+                      columns: [
+                        customDataColumnWidget(labelText: 'Nome'),
+                        customDataColumnWidget(labelText: 'Data de Nascimento'),
+                        customDataColumnWidget(labelText: 'Telefone'),
+                        customDataColumnWidget(labelText: 'Endereço'),
+                        customDataColumnWidget(labelText: 'Cidade'),
+                        customDataColumnWidget(labelText: 'Nome da Mãe'),
+                        customDataColumnWidget(labelText: 'Nome do Pai'),
+                        customDataColumnWidget(labelText: 'Telefone dos Pais'),
+                        customDataColumnWidget(labelText: 'Endereço dos Pais'),
+                        customDataColumnWidget(labelText: 'Problema de Saúde'),
+                        customDataColumnWidget(labelText: 'Batizado',),
+                        customDataColumnWidget(labelText: 'Primeira Comunão'),
+                        customDataColumnWidget(labelText: 'Crismado'),
+                        customDataColumnWidget(labelText: 'Tamanho da Camiseta'),
+                        customDataColumnWidget(labelText: 'Instagram'),
+                        customDataColumnWidget(labelText: 'Carimbo')
+                      ],
+                      rows: List.generate(cursistas.length, (index){
+                        final isSelected = vm.seletecIndex == index;
+
+                        return DataRow(
+                          color: WidgetStateProperty.resolveWith<Color?>(
+                            (Set<WidgetState> states){
+                              return isSelected ? Colors.orange.shade100 : null;
+                            }
+                          ),
+                          cells: cursistas[index].toMap().values.map((value) => customDataCellWidget(value.toString(), vm.zoom, ()=>vm.selectRow(index))).toList(),
+                        );
+                      }),
+                      // rows: cursistas.map((c) {
+                      //   return DataRow(
+                      //     cells: [
+                      //       DataCell(Text(c.nomeCompleto, style: TextStyle(fontSize: 14 * vm.zoom),),),
+                      //       DataCell(Text(c.dataNascimento, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.telefone, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.enderecoResidencial, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.cidade, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.nomeMae, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.nomePai, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.telefonePais, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.enderecoPais, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.problemaSaude, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.batizado, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.primeiraComunhao, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.crismado, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.tamanhoCamiseta, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.instagram, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //       DataCell(Text(c.carimboDataHora, style: TextStyle(fontSize: 14 * vm.zoom),)),
+                      //     ],
+                      //   );
+                      // }).toList(),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      }
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -74,7 +74,7 @@ packages:
     source: hosted
     version: "0.3.4+2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
@@ -150,6 +150,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_advanced_drawer:
+    dependency: "direct main"
+    description:
+      name: flutter_advanced_drawer
+      sha256: "8567eb3751e95e5eac53f81def32d41bfcfa135c9d383f89f089764df6b43274"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   flutter_lints:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=3.3.0 <4.0.0'
 
 dependencies:
+  crypto: ^3.0.6
   csv: ^6.0.0
   cupertino_icons: ^1.0.2
   dotlottie_loader: ^0.0.5
@@ -14,6 +15,7 @@ dependencies:
   file_picker: ^10.1.9
   flutter:
     sdk: flutter
+  flutter_advanced_drawer: ^1.5.0
   flutter_native_splash: ^2.4.6
   go_router: ^15.1.1
   google_fonts: ^6.2.1


### PR DESCRIPTION
The last PR, although the logic was correct, FilePicker generated a unique ID within the cache folder for each file it selected. So, the message that data was already imported would never appear.
With that, I created a HASH based on the file content for comparison.